### PR TITLE
通过这个简单的Dockerfile即可以实现在docker容器里搭建v2-ui的需求

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:16.04
+
+LABEL 99kies 1290017556@qq.com https://github.com/99kies
+
+RUN apt-get update && \
+    apt-get install curl -y && \
+    cd / && \
+    curl -Ls https://blog.sprov.xyz/v2-ui.sh > v2-ui.sh
+
+EXPOSE 65432 32140 32141 32142 32143 32144 32145 32146
+# you can diy it
+
+# xshell1 run: docker build -t v2-ui .
+
+# xshell1 run: docker run -it -p 65432:65432 -p 32140:32140 -p 32141:32141 -p 32142:32142 -p 32143:32143 -p 32144:32144 -p 32145:32145 --privileged --name v2-ui v2-ui  /sbin/init
+
+# xshell2 run: docker exec -it /bin/bash


### PR DESCRIPTION
主要问题就是直接运行docker容器是无法使用systemctl命令的

解决方案就是init在后台运行一个docker容器，然后再用docker exec方法进入容器

所以如果是用xshell的话我们打开两个shell连接到服务器上（xshell1 和 xshell2）


### 第一步
**xshell1：**
_1. build镜像_
`docker build -t v2-ui .`
_2. init后台运行docker容器_
`docker run -it -p 65432:65432 -p 32140:32140 -p 32141:32141 -p 32142:32142 -p 32143:32143 -p 32144:32144 -p 32145:32145 --privileged --name v2-ui v2-ui  /sbin/init`
镜像用的是**ubuntu**系统 所以init在_/sbin/init_。  **centos**系统在_/usr/sbin/init_
这时候就会进入后台，只要在另外一个shell进入容器 进行操作配置即可

### 第二步
**xshell2:**
`docker exec -it v2-ui `
进入之后 
`bash v2-ui.sh`
然后配置一下就可以了
